### PR TITLE
Streaming PUT and GET requests

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@
 
 [ ] Zero copy support (data streaming)
 [ ] Support bigstring
+[x] Basic streaming via cohttp's backend-specific stream types
 
 3.1.0: (unreleased)
 [x] Support HEAD operation on objects.

--- a/aws-s3-async/compat.ml
+++ b/aws-s3-async/compat.ml
@@ -26,6 +26,7 @@ end
 module Cohttp_deferred = struct
   module Body = struct
     type t = Cohttp_async.Body.t
+    let empty = Cohttp_async.Body.empty
     let to_string = Cohttp_async.Body.to_string
     let of_string = Cohttp_async.Body.of_string
   end

--- a/aws-s3-async/compat.mli
+++ b/aws-s3-async/compat.mli
@@ -1,3 +1,5 @@
 (**/**)
-include Aws_s3.Types.Compat with type 'a Deferred.t = 'a Async.Deferred.t
+include Aws_s3.Types.Compat
+  with type 'a Deferred.t = 'a Async.Deferred.t
+  with type Cohttp_deferred.Body.t = Cohttp_async.Body.t
 (**/**)

--- a/aws-s3-lwt/compat.ml
+++ b/aws-s3-lwt/compat.ml
@@ -34,6 +34,7 @@ end
 module Cohttp_deferred = struct
   module Body = struct
     type t = Cohttp_lwt.Body.t
+    let empty = Cohttp_lwt.Body.empty
     let to_string = Cohttp_lwt.Body.to_string
     let of_string = Cohttp_lwt.Body.of_string
   end

--- a/aws-s3-lwt/compat.mli
+++ b/aws-s3-lwt/compat.mli
@@ -1,1 +1,3 @@
-include Aws_s3.Types.Compat with type 'a Deferred.t = 'a Lwt.t
+include Aws_s3.Types.Compat
+  with type 'a Deferred.t = 'a Lwt.t
+  with type Cohttp_deferred.Body.t = Cohttp_lwt.Body.t

--- a/aws-s3/compat.ml
+++ b/aws-s3/compat.ml
@@ -30,6 +30,7 @@ end
 module Cohttp_deferred = struct
   module Body = struct
     type t = Cohttp.Body.t
+    let empty = Cohttp.Body.empty
     let to_string = Cohttp.Body.to_string
     let of_string = Cohttp.Body.of_string
   end

--- a/aws-s3/s3.ml
+++ b/aws-s3/s3.ml
@@ -233,7 +233,7 @@ module Make(Compat : Types.Compat) = struct
     let data = body_of_string data in
     put_body ?scheme ?credentials ?region ?content_type ?content_encoding ?acl ?cache_control ~bucket ~key ~data ()
 
-  let get ?(scheme=`Http) ?credentials ?region ?range ~bucket ~key () =
+  let get_body ?(scheme=`Http) ?credentials ?region ?range ~bucket ~key () =
     let headers =
       let r_opt r = Option.value_map ~f:(string_of_int) ~default:"" r in
 
@@ -254,6 +254,10 @@ module Make(Compat : Types.Compat) = struct
       Util_deferred.make_request ~scheme ?credentials ?region ~headers ~meth:`GET ~path ~query:[] ()
     in
     do_command ?region cmd >>=? fun (_headers, body) ->
+    Deferred.return (Ok body)
+
+  let get ?scheme ?credentials ?region ?range ~bucket ~key () =
+    get_body ?scheme ?credentials ?region ?range ~bucket ~key () >>=? fun body ->
     Cohttp_deferred.Body.to_string body >>= fun body ->
     Deferred.return (Ok body)
 

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -47,7 +47,7 @@ module Make(Compat : Types.Compat) : sig
   (** Upload [key] to [bucket].
       Returns the etag of the object. The etag is the md5 checksum (RFC 1864)
   *)
-  val put_body :
+  val put_stream :
     (?content_type:string ->
      ?content_encoding:string ->
      ?acl:string ->
@@ -81,7 +81,7 @@ module Make(Compat : Types.Compat) : sig
       to use https, please make sure that you have enabled ssl for cohttp
       (opam package tls or lwt_ssl for lwt or async_ssl for async)
   *)
-  val get_body :
+  val get_stream :
     (?range:range -> bucket:string -> key:string -> unit -> Cohttp_deferred.Body.t result) command
 
   (** Download [key] from s3 in [bucket]
@@ -133,7 +133,7 @@ module Make(Compat : Types.Compat) : sig
     (** Upload a part of the file. All parts except the last part must be
         at least 5Mb big. All parts must have a unique part number.
         The final file will be assembled from all parts ordered by part number *)
-    val upload_part_body :
+    val upload_part_stream :
       (t -> part_number:int -> data:Cohttp_deferred.Body.t -> data_length:int -> data_sha256:Digestif.SHA256.Bytes.t -> unit -> unit result) command
 
     (** Upload a part of the file. All parts except the last part must be

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -95,6 +95,17 @@ module Make(Compat : Types.Compat) : sig
       to use https, please make sure that you have enabled ssl for cohttp
       (opam package tls or lwt_ssl for lwt or async_ssl for async)
   *)
+  val get_body :
+    (?range:range -> bucket:string -> key:string -> unit -> Cohttp_deferred.Body.t result) command
+
+  (** Download [key] from s3 in [bucket]
+      If [range] is specified, only a part of the file is retrieved.
+      - If [first] is None, then start from the beginning of the object.
+      - If [last] is None, then get to the end of the object.
+      Scheme defaults to http. If you are uploading across the internet.
+      to use https, please make sure that you have enabled ssl for cohttp
+      (opam package tls or lwt_ssl for lwt or async_ssl for async)
+  *)
   val get :
     (?range:range -> bucket:string -> key:string -> unit -> string result) command
 

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -82,7 +82,7 @@ module Make(Compat : Types.Compat) : sig
       (opam package tls or lwt_ssl for lwt or async_ssl for async)
   *)
   val get_stream :
-    (?range:range -> bucket:string -> key:string -> unit -> Cohttp_deferred.Body.t result) command
+    (?range:range -> bucket:string -> key:string -> unit -> (Cohttp_deferred.Body.t * int) result) command
 
   (** Download [key] from s3 in [bucket]
       If [range] is specified, only a part of the file is retrieved.

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -44,6 +44,35 @@ module Make(Compat : Types.Compat) : sig
 
   type range = { first: int option; last:int option }
 
+  (** A potentially streaming request or response body *)
+  type body
+
+  (** Create a body with pre-computed length and cryptographic hash information
+      specified.  This is mostly useful when setting up a content to stream
+      data to S3. *)
+  val make_body :
+    content:Cohttp_deferred.Body.t ->
+    length:int ->
+    hash:Digestif.SHA256.Bytes.t ->
+    body
+
+  (** Create a {!body} from a string, automatically calculating the length and
+      hash. *)
+  val body_of_string : string -> body
+
+  (** Upload [key] to [bucket].
+      Returns the etag of the object. The etag is the md5 checksum (RFC 1864)
+  *)
+  val put_body :
+    (?content_type:string ->
+     ?content_encoding:string ->
+     ?acl:string ->
+     ?cache_control:string ->
+     bucket:string ->
+     key:string ->
+     data:body ->
+     unit -> string result) command
+
   (** Upload [key] to [bucket].
       Returns the etag of the object. The etag is the md5 checksum (RFC 1864)
   *)
@@ -54,7 +83,8 @@ module Make(Compat : Types.Compat) : sig
      ?cache_control:string ->
      bucket:string ->
      key:string ->
-     data:string -> unit -> string result) command
+     data:string ->
+     unit -> string result) command
 
 
   (** Download [key] from s3 in [bucket]
@@ -102,6 +132,12 @@ module Make(Compat : Types.Compat) : sig
       ?acl:string ->
       ?cache_control:string ->
       bucket:string -> key:string -> unit -> t result) command
+
+    (** Upload a part of the file. All parts except the last part must be
+        at least 5Mb big. All parts must have a unique part number.
+        The final file will be assembled from all parts ordered by part number *)
+    val upload_part_body :
+      (t -> part_number:int -> data:body -> unit -> unit result) command
 
     (** Upload a part of the file. All parts except the last part must be
         at least 5Mb big. All parts must have a unique part number.

--- a/aws-s3/types.ml
+++ b/aws-s3/types.ml
@@ -26,6 +26,7 @@ module type Compat = sig
   module Cohttp_deferred : sig
     module Body : sig
       type t
+      val empty: t
       val to_string: t -> string Deferred.t
       val of_string: string -> t
     end

--- a/aws-s3/util.mli
+++ b/aws-s3/util.mli
@@ -29,22 +29,26 @@ val string_of_region : region -> string
 val region_of_string : string -> region
 val region_of_host : string -> region
 
+type 'content body = {
+  content: 'content;
+  length: int;
+  hash: Digestif.SHA256.Bytes.t;
+}
+
 module Make : functor(Compat: Types.Compat) -> sig
   open Compat
-
-  type body
 
   val make_body :
     content:Cohttp_deferred.Body.t ->
     length:int ->
     hash:Digestif.SHA256.Bytes.t ->
-    body
+    Cohttp_deferred.Body.t body
 
-  val body_of_string : string -> body
+  val body_of_string : string -> Cohttp_deferred.Body.t body
 
   val make_request :
     scheme:[`Http|`Https] ->
-    ?body:body ->
+    ?body:Cohttp_deferred.Body.t body ->
     ?region:region ->
     ?credentials:Credentials.t ->
     headers:(string * string) list ->

--- a/aws-s3/util.mli
+++ b/aws-s3/util.mli
@@ -1,6 +1,5 @@
 (** Utilites *)
 
-open Core
 open Cohttp
 
 type region =
@@ -33,9 +32,19 @@ val region_of_host : string -> region
 module Make : functor(Compat: Types.Compat) -> sig
   open Compat
 
+  type body
+
+  val make_body :
+    content:Cohttp_deferred.Body.t ->
+    length:int ->
+    hash:Digestif.SHA256.Bytes.t ->
+    body
+
+  val body_of_string : string -> body
+
   val make_request :
     scheme:[`Http|`Https] ->
-    ?body:String.t ->
+    ?body:body ->
     ?region:region ->
     ?credentials:Credentials.t ->
     headers:(string * string) list ->


### PR DESCRIPTION
Fixes #4 

To minimize code changes and avoid losing existing integrity checks, potentially streaming uploads must include a pre-specified length and SHA256 hash.

I'm open to name changes/suggestions for the new functions.