### PR TITLE
Update to work with digestif 0.7

### DIFF
--- a/aws-s3.opam
+++ b/aws-s3.opam
@@ -14,7 +14,7 @@ version: "4.1.0"
 depends: [
   "dune" { build }
   "ocaml-inifiles"
-  "digestif" { = "0.6" }
+  "digestif" { >= "0.7" }
   "ptime"
   "uri"
   "xml-light"


### PR DESCRIPTION
Small changes due to `Digestif.SHA256.t` being abstract now rather than just private.