### PR TITLE
Initial pass at non-AWS vendor support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 build:
 	dune build @install
 
+.PHONY: lwt
+lwt:
+	dune build aws-s3-lwt.install
+
+.PHONY: async
+async:
+	dune build aws-s3-async.install
+
 .PHONY: install
 install: build
 	dune install

--- a/aws-s3.opam
+++ b/aws-s3.opam
@@ -14,7 +14,7 @@ version: "4.1.0"
 depends: [
   "dune" { build }
   "ocaml-inifiles"
-  "digestif" { = "0.6" }
+  "digestif" { >= "0.6" }
   "ptime"
   "uri"
   "xml-light"

--- a/aws-s3.opam
+++ b/aws-s3.opam
@@ -14,7 +14,7 @@ version: "4.1.0"
 depends: [
   "dune" { build }
   "ocaml-inifiles"
-  "digestif" { >= "0.6" }
+  "digestif" { = "0.6" }
   "ptime"
   "uri"
   "xml-light"

--- a/aws-s3/aws.mli
+++ b/aws-s3/aws.mli
@@ -2,12 +2,10 @@
 module Make(Io : Types.Io) : sig
   open Io
   val make_request :
-    ?domain:Unix.socket_domain ->
-    scheme:[`Http|`Https] ->
+    endpoint:Region.endpoint ->
     ?expect:bool ->
     sink:string Io.Pipe.writer ->
     ?body:Body.Make(Io).t ->
-    ?region:Region.t ->
     ?credentials:Credentials.t ->
     headers:(string * string) list ->
     meth:[`GET | `PUT | `POST | `DELETE | `HEAD ] ->

--- a/aws-s3/http.ml
+++ b/aws-s3/http.ml
@@ -156,8 +156,8 @@ module Make(Io : Types.Io) = struct
     Or_error.return (code, message, headers, error_body)
 
 
-  let call ?(domain=Unix.PF_INET) ?(expect=false) ~scheme ~host ~path ?(query=[]) ~headers ~sink ?body (meth:meth) =
-    Net.connect ~domain ~host ~scheme >>=? fun (reader, writer) ->
+  let call ?(expect=false) ~(endpoint:Region.endpoint) ~path ?(query=[]) ~headers ~sink ?body (meth:meth) =
+    Net.connect ~inet:endpoint.inet ~host:endpoint.host ~port:endpoint.port ~scheme:endpoint.scheme >>=? fun (reader, writer) ->
     (* At this point we need to make sure reader and writer are closed properly. *)
     do_request ~expect ~path ~query ~headers ~sink ?body meth reader writer >>= fun result ->
     (* Close the reader and writer regardless of status *)

--- a/aws-s3/http.mli
+++ b/aws-s3/http.mli
@@ -7,10 +7,8 @@ module Make : functor(Io: Types.Io) -> sig
   val string_of_method : meth -> string
 
   val call:
-    ?domain:Unix.socket_domain ->
     ?expect:bool ->
-    scheme:[< `Http | `Https ] ->
-    host:string ->
+    endpoint:Region.endpoint ->
     path:string ->
     ?query:(string * string) list ->
     headers:string Headers.t ->

--- a/aws-s3/region.mli
+++ b/aws-s3/region.mli
@@ -1,3 +1,5 @@
+type vendor
+
 type t =
   | Ap_northeast_1
   | Ap_northeast_2
@@ -18,8 +20,23 @@ type t =
   | Us_west_2
   | Ca_central_1
   | Other of string
+  | Vendor of vendor
+
+val vendor : region_name:string -> host:string -> port:int -> t
+
+val minio : host:string -> port:int -> t
+
+type endpoint = {
+  inet: [`V4 | `V6];
+  scheme: [`Http | `Https];
+  host: string;
+  port: int;
+  region: t;
+}
+
+val endpoint :
+  inet:[`V4 | `V6] -> scheme:[`Http | `Https] -> t -> endpoint
 
 val to_string : t -> string
 val of_string : string -> t
 val of_host : string -> t
-val to_host : ?dualstack:bool -> t -> string

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -20,7 +20,7 @@ module Make(Io : Types.Io) : sig
   open Io
 
   type error =
-    | Redirect of Region.t
+    | Redirect of Region.endpoint
     | Throttled
     | Unknown of int * string
     | Failed of exn
@@ -37,7 +37,7 @@ module Make(Io : Types.Io) : sig
   }
 
   type nonrec 'a result = ('a, error) result Deferred.t
-  type 'a command = ?scheme:[`Http|`Https] -> ?credentials:Credentials.t -> ?region:Region.t -> 'a
+  type 'a command = ?credentials:Credentials.t -> endpoint:Region.endpoint -> 'a
 
   module Ls : sig
     type t = (content list * cont) result
@@ -61,13 +61,6 @@ module Make(Io : Types.Io) : sig
   end
 
   type range = { first: int option; last:int option }
-
-  (** Globally switch between IPv4 or IPv6 connections.
-      This will affect all following operations on buckets/objects.
-      Defaut is to use IPv4, but may change in the future.
-      Unix domain sockets are not supported.
-  *)
-  val set_connection_type: Unix.socket_domain -> unit
 
   (** Upload [data] to [bucket]/[key].
       Returns the etag of the object. The etag is the md5 checksum (RFC 1864)
@@ -245,6 +238,6 @@ module Make(Io : Types.Io) : sig
   (** Helper function to handle error codes.
       The function handle redirects and throttling.
   *)
-  val retry : ?region:Region.t -> retries:int ->
-    f:(?region:Region.t -> unit -> 'a result) -> unit -> 'a result
+  val retry : endpoint:Region.endpoint -> retries:int ->
+    f:(endpoint:Region.endpoint -> unit -> 'a result) -> unit -> 'a result
 end

--- a/aws-s3/types.ml
+++ b/aws-s3/types.ml
@@ -85,8 +85,9 @@ module type Io = sig
   (**/**)
   module Net : sig
     val connect :
-      domain:Unix.socket_domain ->
+      inet:[ `V4 | `V6 ] ->
       host:string ->
+      port:int ->
       scheme:[< `Http | `Https ] ->
       (string Pipe.reader * string Pipe.writer) Deferred.Or_error.t
   end

--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+    minio:
+        image: minio/minio
+        volumes:
+            - data:/data
+        ports:
+            - "9000:9000"
+        environment:
+            MINIO_ACCESS_KEY: minio
+            MINIO_SECRET_KEY: minio123
+        command: server /data
+
+volumes:
+    data:


### PR DESCRIPTION
This is _completely_ untested, mostly meant as a check to see what you think of the approach.  It's based roughly on your suggestion in https://github.com/andersfugmann/aws-s3/issues/10#issuecomment-421144964.

`Region.to_port` feels a little hacky, but the changes would be more disruptive without it.

Related to #10 