### PR TITLE
Use native TLS or openssl under Lwt

### DIFF
--- a/aws-s3-lwt/io.ml
+++ b/aws-s3-lwt/io.ml
@@ -166,7 +166,7 @@ module Net = struct
     let addr = Ipaddr_unix.of_inet_addr addr in
     let endp = match scheme with
       | `Http -> `TCP (`IP addr, `Port 80)
-      | `Https -> `OpenSSL (`Hostname host, `IP addr, `Port 443)
+      | `Https -> `TLS (`Hostname host, `IP addr, `Port 443)
     in
     Conduit_lwt_unix.connect
       ~ctx:Conduit_lwt_unix.default_ctx endp >>= fun (_flow, ic, oc) ->


### PR DESCRIPTION
Leave the decision on which to use to Conduit.  As of this writing, it
will use ocaml-tls when it's available, otherwise openssl.

Closes #13 