### PR TITLE
Allow conduit to select ocaml-tls vs openssl

### DIFF
--- a/aws-s3-lwt/io.ml
+++ b/aws-s3-lwt/io.ml
@@ -171,7 +171,7 @@ module Net = struct
     let addr = Ipaddr_unix.of_inet_addr addr in
     let endp = match scheme with
       | `Http -> `TCP (`IP addr, `Port port)
-      | `Https -> `OpenSSL (`Hostname host, `IP addr, `Port port)
+      | `Https -> `TLS (`Hostname host, `IP addr, `Port port)
     in
     Conduit_lwt_unix.connect
       ~ctx:Conduit_lwt_unix.default_ctx endp >>= fun (_flow, ic, oc) ->


### PR DESCRIPTION
This allows conduit to use ocaml-tls or openssl, depending on what's available and what the user chooses.  See the commit message in d9d42c8 for a few more details.

Closes #13 