### PR TITLE
Add support for fetching credentials from environment

### DIFF
--- a/aws-s3/authorization.ml
+++ b/aws-s3/authorization.ml
@@ -126,13 +126,17 @@ let make_presigned_url ?(scheme=`Https) ?host ?port ~credentials ~date ~region ~
   let duration = string_of_int duration in
   let region = Region.to_string region in
   let headers = Headers.singleton "Host" host_header in
-  let query = [
+  let partial_query = [
         ("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
         ("X-Amz-Credential", sprintf "%s/%s/%s/s3/aws4_request" credentials.Credentials.access_key date region);
         ("X-Amz-Date", sprintf "%sT%sZ" date time);
         ("X-Amz-Expires", duration);
         ("X-Amz-SignedHeaders", "host");
       ] in
+  let query = match credentials.token with
+  | Some t -> ("X-Amz-Security-Token", t) :: partial_query
+  | None -> partial_query
+  in
   let scope = make_scope ~date ~region ~service in
   let signing_key = make_signing_key ~date ~region ~service ~credentials () in
   let signature, _signed_headers =

--- a/aws-s3/aws_s3.ml
+++ b/aws-s3/aws_s3.ml
@@ -3,3 +3,4 @@ module Types = Types
 module Credentials = Credentials
 module Region = Region
 module Authorization = Authorization
+module Headers = Headers

--- a/aws-s3/credentials.ml
+++ b/aws-s3/credentials.ml
@@ -74,7 +74,12 @@ module Make(Io : Types.Io) = struct
       let ini = new Inifiles.inifile creds_file in
       let access_key = ini#getval profile "aws_access_key_id" in
       let secret_key = ini#getval profile "aws_secret_access_key" in
-      make ~access_key ~secret_key () |> Deferred.Or_error.return
+      let token = match ini#getval profile "aws_session_token" with
+      | x -> Some x
+      | exception Inifiles.Invalid_element _ -> None
+      | exception Inifiles.Invalid_section _ -> None
+      in
+      make ~access_key ~secret_key ?token () |> Deferred.Or_error.return
   end
 
   module Env = struct


### PR DESCRIPTION
This adds support for fetching credentials from the environment, grabs sessions token from the file if present or ignore otherwise, fixes a bug with presigned urls regarding tokens and exposes the headers so that users can use certain functions in Authorization that require a header. 

Please let me know if you would like anything fixed or changed.  