### PR TITLE
Add previously-transitive Yojson dependency

### DIFF
--- a/aws-s3.opam
+++ b/aws-s3.opam
@@ -21,6 +21,7 @@ depends: [
   "ezxmlm" {>= "1.1.0"}
   "ppx_protocol_conv_xmlm" {>= "5.0.0"}
   "ppx_protocol_conv_json" {>= "5.0.0"}
+  "yojson"
   "cmdliner" {>= "1.1.0"}
   "ppx_inline_test" {with-test}
   "base64" {>= "3.1.0"}

--- a/aws-s3/dune
+++ b/aws-s3/dune
@@ -3,7 +3,7 @@
  (public_name aws-s3)
  (synopsis "Amazon S3 access library")
  (libraries ptime inifiles digestif.c
-            base64 uri
+            base64 uri yojson
             ppx_protocol_conv_json
             ppx_protocol_conv_xmlm str)
  (preprocess (pps ppx_inline_test ppx_protocol_conv))


### PR DESCRIPTION
The code used to implicitly depend on Yojson via a transitive dependency, but it also uses Yojson directly, so it is better to declare it as such.

It doesn't require a lot from Yojson, just `from_string` so I didn't specify any version constraints since the function has been there for a long time.