### PR TITLE
Add x-amz-security-token header when using credential tokens

### DIFF
--- a/aws-s3/authorization.ml
+++ b/aws-s3/authorization.ml
@@ -126,13 +126,19 @@ let make_presigned_url ?(scheme=`Https) ?host ?port ~credentials ~date ~region ~
   let duration = string_of_int duration in
   let region = Region.to_string region in
   let headers = Headers.singleton "Host" host_header in
-  let query = [
+  let query = 
+    let base = [
         ("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
         ("X-Amz-Credential", sprintf "%s/%s/%s/s3/aws4_request" credentials.Credentials.access_key date region);
         ("X-Amz-Date", sprintf "%sT%sZ" date time);
         ("X-Amz-Expires", duration);
         ("X-Amz-SignedHeaders", "host");
-      ] in
+      ]
+    in
+    match credentials.token with
+      | None -> base
+      | Some token -> ("X-Amz-Security-Token", token) :: base
+  in
   let scope = make_scope ~date ~region ~service in
   let signing_key = make_signing_key ~date ~region ~service ~credentials () in
   let signature, _signed_headers =


### PR DESCRIPTION
When using short lived credentials for making s3 requests, we need to
forward the credential token via the X-Amz-Security-Token http header