### PR TITLE
Close input channel too after reading (Lwt)

### DIFF
--- a/aws-s3-lwt/io.ml
+++ b/aws-s3-lwt/io.ml
@@ -199,7 +199,8 @@ module Net = struct
         read ()
     in
     (* We close input and output when input is closed *)
-    Lwt.async (fun () -> Pipe.closed reader >>= fun () -> Lwt_io.close oc);
+    Lwt.async (fun () -> Pipe.closed reader >>= fun () ->
+                Lwt_io.close oc >>= fun () -> Lwt_io.close ic);
     Lwt.async read;
 
     let output, writer = Pipe.create () in


### PR DESCRIPTION
We noticed that the `Lwt` implementation was leaking file descriptors because the input channel was not closed. The sockets would stick around because only the `SHUTDOWN_SEND` command was triggered.

This is especially problematic when using `Lwt` without `libev`. `Lwt` will then fall back to using `select` which is restricted to 1024 file descriptors, see e.g. https://github.com/ocsigen/lwt/issues/222

Closing the input channel too after reading triggers `SHUTDOWN_RECEIVE` through `Conduit_lwt_unix` and allows the file descriptors to be closed. This was actually already suggested in the comment, it was just missing in the code.

I don't think this bug is present in the `Async` implementation, but I only skimmed it; I didn't thoroughly check.