### PR TITLE
Support stateless multipart

### DIFF
--- a/aws-s3/authorization.ml
+++ b/aws-s3/authorization.ml
@@ -278,7 +278,7 @@ let%test "chunk_signature" =
   let expect = "ad80c730a21e5b8d04586a2213dd63b9a0e99e0e2307b0ade35a65485a288648" in
   signature |> to_hex = expect
 
-let%test "presigned_url with custom_query (multipart upload)" =
+let%test "presigned_url with query (multipart upload)" =
   let credentials = Credentials.make
       ~access_key:"AKIAIOSFODNN7EXAMPLE"
       ~secret_key:"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/aws-s3/authorization.ml
+++ b/aws-s3/authorization.ml
@@ -36,7 +36,6 @@ let make_scope ~date ~region ~service =
   sprintf "%s/%s/%s/aws4_request" date region service
 
 let string_to_sign ~date ~time ~verb ~path ~query ~headers ~payload_sha ~scope =
-  let query = List.sort ~cmp:(fun a b -> String.compare (fst a) (fst b)) query in
   assert (Headers.cardinal headers > 0);
   (* Count sizes of headers *)
   let (key_size, value_size) =
@@ -65,6 +64,7 @@ let string_to_sign ~date ~time ~verb ~path ~query ~headers ~payload_sha ~scope =
   let canonical_query =
     query
     |> List.map ~f:(fun (k, v) -> sprintf "%s=%s" (Uri.pct_encode ~component:`Userinfo k) (Uri.pct_encode ~component:`Userinfo v))
+    |> List.sort ~cmp:String.compare
     |> String.concat ~sep:"&"
   in
 

--- a/aws-s3/authorization.ml
+++ b/aws-s3/authorization.ml
@@ -103,7 +103,7 @@ let make_auth_header ~credentials ~scope ~signed_headers ~signature =
     signed_headers
     signature
 
-let make_presigned_url ?(scheme=`Https) ?host ?port ?(custom_query=[]) ~credentials ~date ~region ~path ~bucket ~verb ~duration () =
+let make_presigned_url ?(scheme=`Https) ?host ?port ?(query=[]) ~credentials ~date ~region ~path ~bucket ~verb ~duration () =
   let service = "s3" in
   let ((y, m, d), ((h, mi, s), _)) = Ptime.to_date_time date in
   let verb = match verb with
@@ -140,7 +140,7 @@ let make_presigned_url ?(scheme=`Https) ?host ?port ?(custom_query=[]) ~credenti
       | Some token -> ("X-Amz-Security-Token", token) :: base
     in
     (* Merge custom query parameters with AWS parameters *)
-    custom_query @ base_with_token
+    query @ base_with_token
   in
   let scope = make_scope ~date ~region ~service in
   let signing_key = make_signing_key ~date ~region ~service ~credentials () in
@@ -290,11 +290,11 @@ let%test "presigned_url with custom_query (multipart upload)" =
   let bucket = "examplebucket" in
   let verb = `Put in
   let duration = 86400 in
-  let custom_query = [
+  let query = [
     ("partNumber", "1");
     ("uploadId", "example-upload-id");
   ] in
-  let actual = make_presigned_url ~custom_query ~credentials ~date ~region ~path ~bucket ~verb ~duration () |> Uri.to_string in
+  let actual = make_presigned_url ~query ~credentials ~date ~region ~path ~bucket ~verb ~duration () |> Uri.to_string in
   (* Verify that the URL contains the custom query parameters *)
   let contains_substring s sub = 
     try 

--- a/aws-s3/authorization.mli
+++ b/aws-s3/authorization.mli
@@ -54,7 +54,7 @@ val make_presigned_url :
   ?scheme:[`Http | `Https] ->
   ?host:string ->
   ?port:int ->
-  ?custom_query:(string * string) list ->
+  ?query:(string * string) list ->
   credentials:Credentials.t ->
   date:Ptime.t ->
   region:Region.t ->

--- a/aws-s3/authorization.mli
+++ b/aws-s3/authorization.mli
@@ -54,6 +54,7 @@ val make_presigned_url :
   ?scheme:[`Http | `Https] ->
   ?host:string ->
   ?port:int ->
+  ?custom_query:(string * string) list ->
   credentials:Credentials.t ->
   date:Ptime.t ->
   region:Region.t ->

--- a/aws-s3/s3.ml
+++ b/aws-s3/s3.ml
@@ -460,6 +460,16 @@ module Make(Io : Types.Io) = struct
                key: string;
              }
 
+    (** Create a multipart upload object from explicit parameters.
+        This is useful for stateless workflows where upload metadata is stored in a database. *)
+    let make ~bucket ~key ~upload_id ~parts =
+      let multipart_parts = List.map parts ~f:(fun (part_number, etag) -> { Multipart.part_number; etag }) in
+      { id = upload_id;
+        parts = multipart_parts;
+        bucket;
+        key;
+      }
+
     (** Initiate a multipart upload *)
     let init ?credentials ?connect_timeout_ms ?(confirm_requester_pays=false) ~endpoint ?content_type ?content_encoding ?acl ?cache_control ~bucket ~key  () =
       let path = sprintf "/%s/%s" bucket key in
@@ -539,18 +549,15 @@ module Make(Io : Types.Io) = struct
         t.parts <- { etag; part_number } :: t.parts;
         Deferred.return (Ok ())
 
-    (** Complete the multipart upload with explicit parameters.
-      This is useful for stateless workflows where upload metadata is stored in a database.
+    (** Complete the multipart upload.
       The returned etag is a opaque identifier (not md5)
     *)
-    let complete_stateless ?credentials ?connect_timeout_ms ?(confirm_requester_pays = false) ~endpoint ~bucket ~key
-      ~upload_id ~parts () =
-      let path = sprintf "/%s/%s" bucket key in
-      let query = [ "uploadId", upload_id ] in
+    let complete ?credentials ?connect_timeout_ms ?(confirm_requester_pays = false) ~endpoint t () =
+      let path = sprintf "/%s/%s" t.bucket t.key in
+      let query = [ "uploadId", t.id ] in
       let request =
-        let multipart_parts = List.map parts ~f:(fun (part_number, etag) -> { Multipart.part_number; etag }) in
         let sorted_parts =
-          Stdlib.List.sort (fun a b -> compare a.Multipart.part_number b.part_number) multipart_parts
+          Stdlib.List.sort (fun a b -> compare a.Multipart.part_number b.part_number) t.parts
         in
         Multipart.Complete.(xml_of_request { parts = sorted_parts })
         |> (fun node -> Format.asprintf "%a" Ezxmlm.pp [ node ])
@@ -564,20 +571,11 @@ module Make(Io : Types.Io) = struct
       body >>= fun body ->
       let xml = xmlm_of_string body in
       match Multipart.Complete.response_of_xmlm_exn xml with
-      | { location = _; etag; bucket = resp_bucket; key = resp_key } when resp_bucket = bucket && resp_key = key ->
+      | { location = _; etag; bucket = resp_bucket; key = resp_key } when resp_bucket = t.bucket && resp_key = t.key ->
         Ok etag |> Deferred.return
       | _ ->
         Error (Unknown ((-1), "Bucket/key does not match"))
         |> Deferred.return
-
-    (** Complete the multipart upload.
-      The returned etag is a opaque identifier (not md5)
-    *)
-    let complete ?credentials ?connect_timeout_ms ?(confirm_requester_pays = false) ~endpoint t () =
-      complete_stateless ?credentials ?connect_timeout_ms ~confirm_requester_pays ~endpoint ~bucket:t.bucket ~key:t.key
-        ~upload_id:t.id
-        ~parts:(List.map t.parts ~f:(fun p -> p.Multipart.part_number, p.etag))
-        ()
 
     (** Abort a multipart upload, deleting all specified parts *)
     let abort ?credentials ?connect_timeout_ms ?(confirm_requester_pays=false) ~endpoint t () =

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -196,6 +196,10 @@ module Make(Io : Types.Io) : sig
       ?cache_control:string ->
       bucket:string -> key:string -> unit -> t result) command
 
+    (** Create a multipart upload object from explicit parameters.
+        This is useful for stateless workflows where upload metadata is stored in a database. *)
+    val make : bucket:string -> key:string -> upload_id:string -> parts:(int * string) list -> t
+
     (** Upload a part of the file. All parts except the last part must
        be at least 5Mb big. All parts must have a unique part number.
        The final file will be assembled from all parts ordered by part
@@ -221,12 +225,6 @@ module Make(Io : Types.Io) : sig
     (** Complete a multipart upload. The returned string is an opaque identifier used as etag.
         the etag return is _NOT_ the md5 *)
     val complete : (t -> unit -> etag result) command
-
-(** Complete a multipart upload with explicit parameters.
-    This is useful for stateless workflows where upload metadata is stored in a database.
-    The returned string is an opaque identifier used as etag.
-    the etag return is _NOT_ the md5 *)
-    val complete_stateless : (bucket:string -> key:string -> upload_id:string -> parts:(int * string) list -> unit -> etag result) command
 
     (** Abort a multipart upload. This also discards all uploaded parts. *)
     val abort : (t -> unit -> unit result) command

--- a/aws-s3/s3.mli
+++ b/aws-s3/s3.mli
@@ -222,8 +222,19 @@ module Make(Io : Types.Io) : sig
         the etag return is _NOT_ the md5 *)
     val complete : (t -> unit -> etag result) command
 
+(** Complete a multipart upload with explicit parameters.
+    This is useful for stateless workflows where upload metadata is stored in a database.
+    The returned string is an opaque identifier used as etag.
+    the etag return is _NOT_ the md5 *)
+    val complete_stateless : (bucket:string -> key:string -> upload_id:string -> parts:(int * string) list -> unit -> etag result) command
+
     (** Abort a multipart upload. This also discards all uploaded parts. *)
     val abort : (t -> unit -> unit result) command
+
+    (** Accessor functions *)
+    val get_upload_id : t -> string
+    val get_bucket : t -> string
+    val get_key : t -> string
 
     (** Streaming functions *)
     module Stream : sig


### PR DESCRIPTION
Fixes #39.

Adds the necessary types and functions to perform multipart uploads on a stateless environment.

The first commit 9793d10620e87bd7bf4de86316cd961436b855d4 adds a function `complete_stateless` that takes in the `parts` as argument, and rewrite `complete` in its terms.

The second commit 7a34222cb38294073d7da5ab310697e428314268 allows to pass a `custom_query` argument to `make_presigned_url` so that urls with `partNumber` and `uploadId` in its query params can be presigned.

Please let me know if anything has to be implemented differently, or any additional modifications are needed, thanks!