### PR TITLE
use inifiles instead of ocaml-inifiles

### DIFF
--- a/aws-s3.opam
+++ b/aws-s3.opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "ocaml-inifiles"
+  "inifiles"
   "digestif" {>= "0.7"}
   "ptime"
   "uri"


### PR DESCRIPTION
This is switches from `ocaml-inifiles` to `inifiles`. `inifiles` is the newer version of the package that does not have a dependency on `pcre`. This matters because the underlying system pacakge for pcre (on debian `libpcre3-dev`) is in the process of being deprecated (its not availabel in debian 13). 

Apart from that and being built with dune, inifiles is identical to ocaml-inifiles.